### PR TITLE
Rename `reply_quick_reply` method to `reply_quick_buttons`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ This function will render a bubble and send it to the user.
 ```ruby
  def reply_bubble
 ```
+This function will return a string along with a set of button options specified in an array.
+```ruby
+ def reply_quick_buttons(msg, options=%W(Yes No))
+```
 This function will return a string containing the message a user sent to your bot.
 ```ruby
  def get_message

--- a/lib/bot/base_bot_logic.rb
+++ b/lib/bot/base_bot_logic.rb
@@ -55,7 +55,7 @@ class BaseBotLogic
     end
   end
 
-  def self.reply_quick_reply(msg, options)
+  def self.reply_quick_buttons(msg, options)
     options ||= %W(Yes No)
     if @request_type == "TEXT" or @request_type == "CALLBACK"
       Bot.deliver(

--- a/lib/bot/bot_logic.rb
+++ b/lib/bot/bot_logic.rb
@@ -40,8 +40,8 @@ class BotLogic < BaseBotLogic
 		@current_user.profile = {due_date: due_date.to_s}
 		@current_user.save!
 
-		reply_quick_reply "Okay #{due_date.to_s}. Did I get it right?"
-		state_go		
+		reply_quick_buttons "Okay #{due_date.to_s}. Did I get it right?"
+		state_go
 	rescue ArgumentError
 		reply_message "{Sorry I do not undestand this format|Can you try again? Format is DD/MM/YYYY}"
 	end 


### PR DESCRIPTION
This also documents the use of `reply_quick_buttons` in the README.
